### PR TITLE
Now the publish response in the item entity is validated and if the r…

### DIFF
--- a/modules/entities/ts/item/save.ts
+++ b/modules/entities/ts/item/save.ts
@@ -29,22 +29,22 @@ export class ItemSaveManager {
 				this.#parent.set(data);
 			}
 
-			if (!this.#parent.isUnpublished) {
-				return;
-			}
-
+			if (!this.#parent.isUnpublished) return;
+			
 			const properties = this.#parent.getProperties();
 
 			if (this.#localProvider) {
 				await this.#localProvider.save(properties);
 			}
 
-			await this.#publish(properties);
+			const response = await this.#publish(properties);
+			if (!response?.status) throw response
 			this.#parent.triggerEvent();
 
 			return { status: true };
 		} catch (e) {
 			console.error('error saving', e);
+			return e
 		}
 	};
 

--- a/modules/entities/ts/item/save.ts
+++ b/modules/entities/ts/item/save.ts
@@ -33,12 +33,14 @@ export class ItemSaveManager {
 			
 			const properties = this.#parent.getProperties();
 
+			if (this.#parent.isOnline) {
+				const response = await this.#publish(properties);
+				if (!response.status) throw response;
+			}
+
 			if (this.#localProvider) {
 				await this.#localProvider.save(properties);
 			}
-
-			const response = await this.#publish(properties);
-			if (!response?.status) throw response
 			this.#parent.triggerEvent();
 
 			return { status: true };


### PR DESCRIPTION
# Publish validation
In the item entity the publish response was not being validated correctly which caused that when there was an error in the process it did not reach the final response of the publisher.

# isUnpublished validation when the publish provider method return an error.
Previously I used to save in indexedDB regardless of whether the publish was done correctly online which gave problems with the isUnpublished property because if it was saved correctly in indexedDB but not saved online (using the provider's publish) the isUnpublished property would be set to false anyway.


Now it is validated if it is necessary to publish the provider, if yes it waits that the response of this is correct to update the record in indexedDB, in case it does not apply to publish the provider (in case it is in offline mode) the publish of the provider is omitted and the saving in indexedDB is done directly.