### PR TITLE
fix: Solve save method error handling in the item entity

### DIFF
--- a/library/modules/entities/item/save.ts
+++ b/library/modules/entities/item/save.ts
@@ -1,4 +1,3 @@
-import type { ResponseAdapter } from '../adapter';
 import { IResponseAdapter } from '../adapter/interface';
 import type { Item } from './index';
 import type { LocalProvider } from './local-provider';
@@ -43,9 +42,10 @@ export class ItemSaveManager {
 			let remoteResponse;
 			if (this.#parent.isOnline && this.#provider) {
 				const response = await this.#publish(properties);
+				if (!response.status) throw response;
 				this.#localProvider.registry.setValues(response.data);
 				properties.id = response?.data?.id;
-				remoteResponse = this.#adapter.fromRemote(response);
+				remoteResponse = response;
 				this.#localProvider.registry.isNew = false;
 			}
 


### PR DESCRIPTION
resolves #30 

### Fix Incorrect Error Handling in `save` Method by Removing `fromRemote` Call

---

### **Description:**

This PR addresses the issue where the `save` method incorrectly handles the response from the `publish` method in the `@beyond-js/reactive` package (version `1.1.12`). The bug caused a generic error message (`"ERROR_DATA_QUERY"`) to be thrown instead of the actual backend error.

### **Changes:**
1. Removed the line that calls `fromRemote` on the `publish` method's response (`remoteResponse = this.#adapter.fromRemote(response);`) in the `save` method.
2. Updated the `save` method to handle the `publish` response directly and correctly propagate errors by throwing the response if `status: false`.
3. Ensured the actual error from the backend is returned to the client, improving error handling.

### **Updated `save` Method:**

```ts
save = async (data?) => {
    try {
        await this.#getProperty('checkReady')();

        if (data) {
            await this.#parent.set(data);
        }

        if (!this.#parent.isUnpublished) return;

        const properties = { ...data, ...this.#parent.getProperties() };
        properties.isNew = this.#localProvider.registry.isNew;
        properties.__instanceId = this.#localProvider.registry.__instanceId;

        let remoteResponse;
        if (this.#parent.isOnline && this.#provider) {
            const response = await this.#publish(properties);

            if (!response.status) throw response;  // Properly handle errors here

            this.#localProvider.registry.setValues(response.data);
            properties.id = response?.data?.id;
            remoteResponse = response;
            this.#localProvider.registry.isNew = false;
        }

        if (this.#localProvider) {
            await this.#localProvider.save(properties);
        }
        this.#parent.triggerEvent();

        return this.#adapter.toClient({ data: remoteResponse });
    } catch (e) {
        return e;
    }
};
```

### **Why the Fix is Necessary:**

Previously, when `publish` returned an error, the response was passed into `fromRemote`, which expected a different structure, leading to an invalid error message being thrown. This prevented meaningful error messages from being passed to the client, complicating debugging and error handling.

---

### **Testing:**

- **Reproduction Steps:**
  1. Trigger an error in the backend and ensure that the error is properly thrown and propagated by the `save` method.
  2. Verify that the client receives the correct error response instead of `"ERROR_DATA_QUERY"`.

---

This PR improves error handling consistency and makes backend error responses more transparent to the client.
